### PR TITLE
templ version

### DIFF
--- a/styledjsx_test.go
+++ b/styledjsx_test.go
@@ -211,3 +211,65 @@ export default function () {
 	`
 	diff.TestContent(t, actual, expected)
 }
+
+func TestTempl(t *testing.T) {
+	input := `
+templ Story(story *hackernews.Story) {
+  <div class="story">
+    <div>
+      <a>
+        { story.Title }
+      </a>
+      if story.URL  != "" {
+        <a class="url" href={ templ.URL(story.URL) }>({ formatURL(story.URL) })</a>
+      }
+    </div>
+    <div class="meta">
+      { strconv.Itoa(story.Points) } points by { story.Author } • { " " }
+      @Time(story.CreatedAt)
+    </div>
+    <style scoped>{` + "`" + `
+      .story {
+        background: red;
+      }
+      .url {
+        text-transform: none;
+      }
+      .meta {
+        padding: 10px;
+      }
+    ` + "`" + `}</style>
+  </div>
+}
+`
+
+	rewriter := styledjsx.New()
+	actual, err := rewriter.Rewrite("input.jsx", string(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := `
+    import Style from "styled-jsx";
+
+    templ Story(story *hackernews.Story) {
+      <div class="jsx-4GjC3K story">
+        <div class="jsx-4GjC3K">
+          <a class="jsx-4GjC3K">
+            { story.Title }
+          </a>
+          if story.URL  != "" {
+            <a class="jsx-4GjC3K url" href={ templ.URL(story.URL) }>({ formatURL(story.URL) })</a>
+          }
+        </div>
+        <div class="jsx-4GjC3K meta">
+          { strconv.Itoa(story.Points) } points by { story.Author } • { " " }
+          @Time(story.CreatedAt)
+        </div>
+        <Style scoped id="jsx-4GjC3K">{` + "`" + `.story.jsx-4GjC3K { background: red }
+    .url.jsx-4GjC3K { text-transform: none }
+    .meta.jsx-4GjC3K { padding: 10px }` + "`" + `}</Style>
+      </div>
+    }
+  `
+	diff.TestContent(t, actual, expected)
+}

--- a/styledjsx_test.go
+++ b/styledjsx_test.go
@@ -214,6 +214,8 @@ export default function () {
 
 func TestTempl(t *testing.T) {
 	input := `
+package view
+
 templ Story(story *hackernews.Story) {
   <div class="story">
     <div>
@@ -249,27 +251,28 @@ templ Story(story *hackernews.Story) {
 		t.Fatal(err)
 	}
 	expected := `
-    import Style from "styled-jsx";
+import Style from "styled-jsx";
 
-    templ Story(story *hackernews.Story) {
-      <div class="jsx-4GjC3K story">
-        <div class="jsx-4GjC3K">
-          <a class="jsx-4GjC3K">
-            { story.Title }
-          </a>
-          if story.URL  != "" {
-            <a class="jsx-4GjC3K url" href={ templ.URL(story.URL) }>({ formatURL(story.URL) })</a>
-          }
-        </div>
-        <div class="jsx-4GjC3K meta">
-          { strconv.Itoa(story.Points) } points by { story.Author } • { " " }
-          @Time(story.CreatedAt)
-        </div>
-        <Style scoped id="jsx-4GjC3K">{` + "`" + `.story.jsx-4GjC3K { background: red }
-    .url.jsx-4GjC3K { text-transform: none }
-    .meta.jsx-4GjC3K { padding: 10px }` + "`" + `}</Style>
-      </div>
-    }
-  `
+package view
+
+templ Story(story *hackernews.Story) {
+  <div class="jsx-4GjC3K story">
+    <div class="jsx-4GjC3K">
+      <a class="jsx-4GjC3K">
+        { story.Title }
+      </a>
+      if story.URL  != "" {
+        <a class="jsx-4GjC3K url" href={ templ.URL(story.URL) }>({ formatURL(story.URL) })</a>
+      }
+    </div>
+    <div class="jsx-4GjC3K meta">
+      { strconv.Itoa(story.Points) } points by { story.Author } • { " " }
+      @Time(story.CreatedAt)
+    </div>
+    <Style scoped id="jsx-4GjC3K">{` + "`" + `.story.jsx-4GjC3K { background: red }
+.url.jsx-4GjC3K { text-transform: none }
+.meta.jsx-4GjC3K { padding: 10px }` + "`" + `}</Style>
+  </div>
+}`
 	diff.TestContent(t, actual, expected)
 }


### PR DESCRIPTION
https://github.com/a-h/templ/issues/740

Input:

```templ
package view

templ Story(story *hackernews.Story) {
  <div class="story">
    <div>
      <a>
        { story.Title }
      </a>
      if story.URL  != "" {
        <a class="url" href={ templ.URL(story.URL) }>({ formatURL(story.URL) })</a>
      }
    </div>
    <div class="meta">
      { strconv.Itoa(story.Points) } points by { story.Author } • { " " }
      @Time(story.CreatedAt)
    </div>
    <style scoped>{`
      .story {
        background: red;
      }
      .url {
        text-transform: none;
      }
      .meta {
        padding: 10px;
      }
    `}</style>
  </div>
}
```

Output:

```templ
import Style from "styled-jsx";

package view

templ Story(story *hackernews.Story) {
  <div class="jsx-4GjC3K story">
    <div class="jsx-4GjC3K">
      <a class="jsx-4GjC3K">
        { story.Title }
      </a>
      if story.URL  != "" {
        <a class="jsx-4GjC3K url" href={ templ.URL(story.URL) }>({ formatURL(story.URL) })</a>
      }
    </div>
    <div class="jsx-4GjC3K meta">
      { strconv.Itoa(story.Points) } points by { story.Author } • { " " }
      @Time(story.CreatedAt)
    </div>
    <Style scoped id="jsx-4GjC3K">{`.story.jsx-4GjC3K { background: red }
.url.jsx-4GjC3K { text-transform: none }
.meta.jsx-4GjC3K { padding: 10px }`}</Style>
  </div>
}
```

Issues (so far):
- [ ] Scoped CSS is not removed
- [ ] `import Style from "styled-jsx";` is invalid
- [ ] No way in `styledjsx` yet to yank out the CSS